### PR TITLE
Fixes asked in the code review

### DIFF
--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
@@ -74,7 +74,12 @@ public class BlameCommit extends RestApiCaller {
         //calling the API calling method
         IntStream.range(0, commitsInTheGivenPatch.length).mapToObj(i -> commitsInTheGivenPatch[i]).forEach(commitHash -> {
             setUrlForSearchingCommits(commitHash);
-            JSONObject jsonObject = (JSONObject) restApiCaller.callingTheAPI(getUrlForSearchingCommits(), gitHubToken, true, false);
+            JSONObject jsonObject = null;
+            try {
+                jsonObject = (JSONObject) restApiCaller.callingTheAPI(getUrlForSearchingCommits(), gitHubToken, true, false);
+            } catch (Exception e) {
+                System.out.println(e.getMessage() + "cause" + e.getCause());
+            }
             saveRepoNamesInAnArray(jsonObject, commitHash, gitHubToken);
         });
         return commitHashObtainedForPRReview;
@@ -109,7 +114,12 @@ public class BlameCommit extends RestApiCaller {
             fileNames.clear();
             lineRangesChanged.clear();
             patchString.clear();
-            Map<String, ArrayList<String>> mapWithFileNamesAndPatch = gitHubAuthentication.gettingFilesChanged(repoLocation[i], commitHash);
+            Map<String, ArrayList<String>> mapWithFileNamesAndPatch = null;
+            try {
+                mapWithFileNamesAndPatch = gitHubAuthentication.gettingFilesChanged(repoLocation[i], commitHash);
+            } catch (Exception e) {
+                System.out.println(e.getMessage() + "cause" + e.getCause());
+            }
             fileNames = mapWithFileNamesAndPatch.get("fileNames");
             patchString = mapWithFileNamesAndPatch.get("patchString");
             savingRelaventEditLineNumbers(fileNames, patchString);

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
@@ -71,14 +71,6 @@ public class BlameCommit extends RestApiCaller {
         this.urlForObtainingCommits = "https://api.github.com/search/commits?q=hash%3A" + commitHash;
     }
 
-    public String getUrlForGetingFilesChanged() {
-        return urlForGetingFilesChanged;
-    }
-
-    public void setUrlForGetingFilesChanged(String repoName, String commitHash) {
-        this.urlForGetingFilesChanged = "http://api.github.com/repos/" + repoName + "/commits/" + commitHash;
-    }
-
     /**
      * This method is used for obtaining the repositories that contain the relevant commits belongs to the given patch
      *
@@ -118,10 +110,7 @@ public class BlameCommit extends RestApiCaller {
         }
         BlameCommitLogger.info("Repo names having the given commit are successfully saved in an array");
 
-        //==========================================================================================================
         GitHubAuthentication gitHubAuthentication = new GitHubAuthentication(gitHubToken);
-
-        //==========================================================================================================
 
         //        for running through the repoName Array
         for (int i = 0; i < repoLocation.length; i++) {
@@ -132,17 +121,12 @@ public class BlameCommit extends RestApiCaller {
                 patchString.clear();
                 //authorNames.clear();
 
-                //==============================================================================================
-
                 Map<String, ArrayList<String>> mapWithFileNamesAndPatch = gitHubAuthentication.gettingFilesChanged(repoLocation[i], commitHash);
 
                 fileNames = mapWithFileNamesAndPatch.get("fileNames");
                 patchString = mapWithFileNamesAndPatch.get("patchString");
 
                 savingRelaventEditLineNumbers(fileNames, patchString);
-
-
-                //==============================================================================================
 
                 iteratingOver(repoLocation[i], commitHash, gitHubToken);
             }
@@ -152,7 +136,7 @@ public class BlameCommit extends RestApiCaller {
         System.out.println(commitHashObtainedForPRReview);
     }
 
-     /**
+    /**
      * @param fileNames
      * @param patchString
      */

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
@@ -51,7 +51,7 @@ public class BlameCommit extends RestApiCaller {
     private String repoLocation[];
     GraphQlApiCaller graphQlApiCaller = new GraphQlApiCaller();
 
-    private static final Logger BlameCommitLogger = Logger.getLogger(BlameCommit.class);
+    private static final Logger logger = Logger.getLogger(BlameCommit.class);
 
     public String getUrlForSearchingCommits() {
         return urlForObtainingCommits;
@@ -103,7 +103,7 @@ public class BlameCommit extends RestApiCaller {
             JSONObject repositoryJsonObject = (JSONObject) jsonObject.get("repository");
             repoLocation[i] = (String) repositoryJsonObject.get("full_name");
         });
-        BlameCommitLogger.info("Repo names having the given commit are successfully saved in an array");
+        logger.info("Repo names having the given commit are successfully saved in an array");
 
         GitHubAuthentication gitHubAuthentication = new GitHubAuthentication(gitHubToken);
 
@@ -201,7 +201,7 @@ public class BlameCommit extends RestApiCaller {
                 //            calling the graphql API for getting blame information for the current file and saving it in a location.
                 rootJsonObject = (JSONObject) graphQlApiCaller.callingGraphQl(graphqlApiJsonObject, gitHubToken);
             } catch (IOException e) {
-                BlameCommitLogger.error("IO exception occurred when calling the github graphQL API ", e);
+                logger.error("IO exception occurred when calling the github graphQL API ", e);
                 e.printStackTrace();
             }
             //            reading the above saved output for the current selected file name
@@ -210,7 +210,7 @@ public class BlameCommit extends RestApiCaller {
             // parent commit hashes are stored in the arraylist for the given file
 
             iteratingOverForFindingAuthors(owner, repositoryName, fileName, arrayListOfRelevantChangedLines, gitHubToken);
-            BlameCommitLogger.info("Authors of the bug lines of code which are being fixed from the given patch are saved successfully to authorNames SET");
+            logger.info("Authors of the bug lines of code which are being fixed from the given patch are saved successfully to authorNames SET");
         });
     }
 
@@ -318,7 +318,7 @@ public class BlameCommit extends RestApiCaller {
                         commitHashesOfTheParent.add(commitHash);
 
                     });
-                    BlameCommitLogger.info("Parent Commits hashes of the lines which are being fixed by the patch are saved to commitHashesOfTheParent SET successfully ");
+                    logger.info("Parent Commits hashes of the lines which are being fixed by the patch are saved to commitHashesOfTheParent SET successfully ");
                 }
             }
         });
@@ -344,7 +344,7 @@ public class BlameCommit extends RestApiCaller {
                 rootJsonObject = (JSONObject) graphQlApiCaller.callingGraphQl(graphqlApiJsonObject, gitHubToken);
                 readingTheBlameReceivedForAFile(rootJsonObject, arrayListOfRelevantChangedLines, true);
             } catch (IOException e) {
-                BlameCommitLogger.error("IO Exception occured when calling the github graphQL API for finding the authors of the bug lines which are being fixed by the given patch", e);
+                logger.error("IO Exception occured when calling the github graphQL API for finding the authors of the bug lines which are being fixed by the given patch", e);
                 e.printStackTrace();
             }
         });

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.wso2.code.quality.matrices;

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/BlameCommit.java
@@ -18,32 +18,21 @@
 
 package com.wso2.code.quality.matrices;
 
-import java.io.BufferedReader;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.IntStream;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.log4j.Logger;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.json.JSONTokener;
 
 /**
  * This class is used for getting the blame information on relevant lines changeed from the given patch
@@ -62,8 +51,7 @@ public class BlameCommit extends RestApiCaller {
     private String repoLocation[];
     GraphQlApiCaller graphQlApiCaller = new GraphQlApiCaller();
 
-    private static final Logger BlameCommitLogger = Logger.getLogger(BlameCommit.class.getName());
-
+    private static final Logger BlameCommitLogger = Logger.getLogger(BlameCommit.class);
 
     public String getUrlForSearchingCommits() {
         return urlForObtainingCommits;
@@ -169,7 +157,7 @@ public class BlameCommit extends RestApiCaller {
                 lineChanges[j] = intialLineNoInOldFile + "," + endLineNoOfOldFile + "/" + intialLineNoInNewFile + "," + endLineNoOfNewFile;
             });
             ArrayList<String> tempArrayList = new ArrayList<>(Arrays.asList(lineChanges));
-            //adding to the array list which keep track of the line ranges which are being changed to the main arrayList
+            //adding to the array list which keep track of the line ranges being changed
             lineRangesChanged.add(tempArrayList);
         });
         System.out.println("done saving file names and their relevant modification line ranges");

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/CodeQualityMatricesException.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/CodeQualityMatricesException.java
@@ -16,24 +16,13 @@
  * under the License.
  */
 
-package com.wso2.code.quality.matrices;/*
-*  Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+package com.wso2.code.quality.matrices;
 
+/**
+ * The exception class for all Code Quality Matrices project related exceptions
+ *
+ *
+ */
 public class CodeQualityMatricesException extends Exception {
     public CodeQualityMatricesException(String message) {
         super(message);

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/CodeQualityMatricesException.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/CodeQualityMatricesException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.code.quality.matrices;/*
+*  Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+public class CodeQualityMatricesException extends Exception {
+    public CodeQualityMatricesException(String message) {
+        super(message);
+    }
+    public CodeQualityMatricesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
@@ -1,21 +1,22 @@
-package com.wso2.code.quality.matrices;/*
-*  Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
+package com.wso2.code.quality.matrices;
 
 import org.apache.log4j.Logger;
 import org.eclipse.egit.github.core.CommitFile;

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
@@ -70,13 +70,17 @@ public class GitHubAuthentication {
             RepositoryCommit repositoryCommit = commitService.getCommit(iRepositoryIdProvider, commitHash);
             List<CommitFile> filesChanged = repositoryCommit.getFiles();
 
-            Iterator listIterator = filesChanged.iterator();
-            while (listIterator.hasNext()) {
-                CommitFile commitFile = (CommitFile) listIterator.next();
+//            Iterator listIterator = filesChanged.iterator();
+            // this can be run parallely as patchString of a file will always be in the same index as the file
+            filesChanged.parallelStream().forEach(commitFile -> {
                 fileNames.add(commitFile.getFilename());
                 patchString.add(commitFile.getPatch());
-
-            }
+            });
+//            while (listIterator.hasNext()) {
+//                CommitFile commitFile = (CommitFile) listIterator.next();
+//
+//
+//            }
 //            System.out.println(fileNames);
             mapWithFileNamesAndPatches.put("fileNames", fileNames);
             mapWithFileNamesAndPatches.put("patchString", patchString);

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
@@ -43,7 +43,7 @@ public class GitHubAuthentication {
     protected ArrayList<String> fileNames = new ArrayList<String>();
     protected ArrayList<String> patchString = new ArrayList<String>();
 
-    private static final Logger githubAuthenticationLogger = Logger.getLogger(GitHubAuthentication.class);
+    private static final Logger logger = Logger.getLogger(GitHubAuthentication.class);
 
     GitHubAuthentication(String githubToken) {
         gitHubClient = new GitHubClient();
@@ -68,11 +68,11 @@ public class GitHubAuthentication {
                 fileNames.add(commitFile.getFilename());
                 patchString.add(commitFile.getPatch());
             });
-            githubAuthenticationLogger.info("for" + commitHash + " on the " + repositoryName + " repository, files changed and their relevant changed line ranges added to the arraylists successfully");
+            logger.info("for" + commitHash + " on the " + repositoryName + " repository, files changed and their relevant changed line ranges added to the arraylists successfully");
             mapWithFileNamesAndPatches.put("fileNames", fileNames);
             mapWithFileNamesAndPatches.put("patchString", patchString);
         } catch (IOException e) {
-            githubAuthenticationLogger.error("IO Exception occurred when getting the commit with the given SHA form the given repository ",e);
+            logger.error("IO Exception occurred when getting the commit with the given SHA form the given repository ",e);
             throw new CodeQualityMatricesException("IO Exception occurred when getting the commit with the given SHA form the given repository ",e);
         }
         return mapWithFileNamesAndPatches;

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
@@ -17,10 +17,9 @@ package com.wso2.code.quality.matrices;/*
 */
 
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
 import org.eclipse.egit.github.core.CommitFile;
 import org.eclipse.egit.github.core.IRepositoryIdProvider;
-import org.eclipse.egit.github.core.Repository;
 import org.eclipse.egit.github.core.RepositoryCommit;
 import org.eclipse.egit.github.core.client.GitHubClient;
 import org.eclipse.egit.github.core.service.CommitService;
@@ -29,7 +28,6 @@ import org.eclipse.egit.github.core.service.RepositoryService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -44,14 +42,13 @@ public class GitHubAuthentication {
     protected ArrayList<String> fileNames = new ArrayList<String>();
     protected ArrayList<String> patchString = new ArrayList<String>();
 
+    private static final Logger githubAuthenticationLogger = Logger.getLogger(GitHubAuthentication.class);
 
     GitHubAuthentication(String githubToken) {
         gitHubClient = new GitHubClient();
         gitHubClient.setOAuth2Token(githubToken);
         commitService = new CommitService(gitHubClient);
         repositoryService = new RepositoryService(gitHubClient);
-
-
     }
 
     /**
@@ -61,36 +58,21 @@ public class GitHubAuthentication {
      */
     public Map<String, ArrayList<String>> gettingFilesChanged(String repositoryName, String commitHash) {
         Map<String, ArrayList<String>> mapWithFileNamesAndPatches = new HashMap<>();
-
         try {
-//            Repository repository = repositoryService.getRepository("wso2", "carbon-apimgt");
-//            String id = repository.generateId();
-
             IRepositoryIdProvider iRepositoryIdProvider = () -> repositoryName;
             RepositoryCommit repositoryCommit = commitService.getCommit(iRepositoryIdProvider, commitHash);
             List<CommitFile> filesChanged = repositoryCommit.getFiles();
-
-//            Iterator listIterator = filesChanged.iterator();
             // this can be run parallely as patchString of a file will always be in the same index as the file
             filesChanged.parallelStream().forEach(commitFile -> {
                 fileNames.add(commitFile.getFilename());
                 patchString.add(commitFile.getPatch());
             });
-//            while (listIterator.hasNext()) {
-//                CommitFile commitFile = (CommitFile) listIterator.next();
-//
-//
-//            }
-//            System.out.println(fileNames);
+            githubAuthenticationLogger.info("for" + commitHash + " on the " + repositoryName + " repository, files changed and their relevant changed line ranges added to the arraylists successfully");
             mapWithFileNamesAndPatches.put("fileNames", fileNames);
             mapWithFileNamesAndPatches.put("patchString", patchString);
-
-
         } catch (IOException e) {
             e.printStackTrace();
         }
         return mapWithFileNamesAndPatches;
-
     }
-
 }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
@@ -57,7 +57,7 @@ public class GitHubAuthentication {
      * @param commitHash     The querying commit hash
      * @return a map containg arraylist of file changed and their relevant patch
      */
-    public Map<String, ArrayList<String>> gettingFilesChanged(String repositoryName, String commitHash) {
+    public Map<String, ArrayList<String>> gettingFilesChanged(String repositoryName, String commitHash) throws CodeQualityMatricesException {
         Map<String, ArrayList<String>> mapWithFileNamesAndPatches = new HashMap<>();
         try {
             IRepositoryIdProvider iRepositoryIdProvider = () -> repositoryName;
@@ -72,7 +72,8 @@ public class GitHubAuthentication {
             mapWithFileNamesAndPatches.put("fileNames", fileNames);
             mapWithFileNamesAndPatches.put("patchString", patchString);
         } catch (IOException e) {
-            e.printStackTrace();
+            githubAuthenticationLogger.error("IO Exception occurred when getting the commit with the given SHA form the given repository ",e);
+            throw new CodeQualityMatricesException("IO Exception occurred when getting the commit with the given SHA form the given repository ",e);
         }
         return mapWithFileNamesAndPatches;
     }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GitHubAuthentication.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- *
+ * This class is used for communicating with the github REST API from egit github API
  */
 
 public class GitHubAuthentication {
@@ -54,6 +54,11 @@ public class GitHubAuthentication {
 
     }
 
+    /**
+     * @param repositoryName The repository name that contain the given commit hash
+     * @param commitHash     The querying commit hash
+     * @return a map containg arraylist of file changed and their relevant patch
+     */
     public Map<String, ArrayList<String>> gettingFilesChanged(String repositoryName, String commitHash) {
         Map<String, ArrayList<String>> mapWithFileNamesAndPatches = new HashMap<>();
 

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GraphQlApiCaller.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GraphQlApiCaller.java
@@ -1,0 +1,109 @@
+package com.wso2.code.quality.matrices;/*
+*  Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+
+public class GraphQlApiCaller {
+
+    protected static final Logger GraphQlApiCallerLogger= Logger.getLogger(GraphQlApiCaller.class.getName());
+
+    /**
+     * Calling the github graphQL API
+     *
+     * @param queryObject the JSONObject required for querying
+     * @param gitHubToken github token for accessing github GraphQL API
+     * @return Depending on the content return a JSONObject or a JSONArray
+     * @throws IOException
+     */
+    public Object callingGraphQl(JSONObject queryObject, String gitHubToken) throws IOException {
+
+        CloseableHttpClient client = null;
+        CloseableHttpResponse response = null;
+        client = HttpClients.createDefault();
+        HttpPost httpPost = new HttpPost("https://api.github.com/graphql");
+        httpPost.addHeader("Authorization", "Bearer " + gitHubToken);
+        httpPost.addHeader("Accept", "application/json");
+        Object returnedObject = null;
+
+        try {
+            StringEntity entity = new StringEntity(queryObject.toString());
+            httpPost.setEntity(entity);
+            response = client.execute(httpPost);
+
+        } catch (UnsupportedEncodingException e) {
+            GraphQlApiCallerLogger.error("Encoding error occured before calling the github graphQL API", e);
+            e.printStackTrace();
+        } catch (ClientProtocolException e) {
+            GraphQlApiCallerLogger.error("Client protocol exception occurred when calling the github graphQL API", e);
+
+            e.printStackTrace();
+        } catch (IOException e) {
+            GraphQlApiCallerLogger.error("IO Exception occured when calling the github graphQL API", e);
+
+            e.printStackTrace();
+        }
+
+        BufferedReader bufferedReader = null;
+        try {
+            bufferedReader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
+            String line;
+            StringBuilder stringBuilder = new StringBuilder();
+            while ((line = bufferedReader.readLine()) != null) {
+
+                stringBuilder.append(line);
+            }
+
+            String jsonText = stringBuilder.toString();
+            Object json = new JSONTokener(jsonText).nextValue();     // gives an object http://stackoverflow.com/questions/14685777/how-to-check-if-response-from-server-is-jsonaobject-or-jsonarray
+
+            if (json instanceof JSONObject) {
+                JSONObject jsonObject = (JSONObject) json;
+                returnedObject = jsonObject;
+            } else if (json instanceof JSONArray) {
+                JSONArray jsonArray = (JSONArray) json;
+                returnedObject = jsonArray;
+            }
+
+            //            System.out.println(stringBuilder.toString());
+        } catch (Exception e) {
+            GraphQlApiCallerLogger.error("Exception occured when reading the response received from github graphQL API", e);
+            e.printStackTrace();
+        } finally {
+
+            if (bufferedReader != null) {
+                bufferedReader.close();
+            }
+        }
+
+        return returnedObject;
+    }
+}

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GraphQlApiCaller.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GraphQlApiCaller.java
@@ -34,7 +34,7 @@ import java.io.UnsupportedEncodingException;
 
 public class GraphQlApiCaller {
 
-    protected static final Logger GraphQlApiCallerLogger= Logger.getLogger(GraphQlApiCaller.class.getName());
+    protected static final Logger GraphQlApiCallerLogger = Logger.getLogger(GraphQlApiCaller.class);
 
     /**
      * Calling the github graphQL API
@@ -103,7 +103,6 @@ public class GraphQlApiCaller {
                 bufferedReader.close();
             }
         }
-
         return returnedObject;
     }
 }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GraphQlApiCaller.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GraphQlApiCaller.java
@@ -36,7 +36,7 @@ import java.io.UnsupportedEncodingException;
 
 public class GraphQlApiCaller {
 
-    protected static final Logger GraphQlApiCallerLogger = Logger.getLogger(GraphQlApiCaller.class);
+    protected static final Logger logger = Logger.getLogger(GraphQlApiCaller.class);
 
     /**
      * Calling the github graphQL API
@@ -62,14 +62,14 @@ public class GraphQlApiCaller {
             response = client.execute(httpPost);
 
         } catch (UnsupportedEncodingException e) {
-            GraphQlApiCallerLogger.error("Encoding error occured before calling the github graphQL API", e);
+            logger.error("Encoding error occured before calling the github graphQL API", e);
             e.printStackTrace();
         } catch (ClientProtocolException e) {
-            GraphQlApiCallerLogger.error("Client protocol exception occurred when calling the github graphQL API", e);
+            logger.error("Client protocol exception occurred when calling the github graphQL API", e);
 
             e.printStackTrace();
         } catch (IOException e) {
-            GraphQlApiCallerLogger.error("IO Exception occured when calling the github graphQL API", e);
+            logger.error("IO Exception occured when calling the github graphQL API", e);
 
             e.printStackTrace();
         }
@@ -97,7 +97,7 @@ public class GraphQlApiCaller {
 
             //            System.out.println(stringBuilder.toString());
         } catch (Exception e) {
-            GraphQlApiCallerLogger.error("Exception occured when reading the response received from github graphQL API", e);
+            logger.error("Exception occured when reading the response received from github graphQL API", e);
             e.printStackTrace();
         } finally {
 

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GraphQlApiCaller.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/GraphQlApiCaller.java
@@ -1,20 +1,22 @@
-package com.wso2.code.quality.matrices;/*
-*  Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.code.quality.matrices;
 
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * should be passed as command line arguments when running the application
  */
 public class MainClass {
-    private final static Logger logger = Logger.getLogger(MainClass.class.getName());
+    private final static Logger logger = Logger.getLogger(MainClass.class);
 
     public static void main(String[] args) {
         logger.info(" Main method got executed");
@@ -60,6 +60,5 @@ public class MainClass {
 
         Reviewers reviewers = new Reviewers();
         reviewers.findingReviewers(commitHashObtainedForPRReview, gitHubToken);
-
     }
 }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.wso2.code.quality.matrices;

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
@@ -44,14 +44,17 @@ public class MainClass {
         try {
             jsonArray = (JSONArray) restApiCaller.callingTheAPI(pmtUrl, pmtToken, false, false);
         } catch (Exception e) {
-            System.out.println(e.getMessage()+"cause"+e.getCause());
+            System.out.println(e.getMessage() + "cause" + e.getCause());
 
         }
 
         logger.info("JSON response is received successfully from WSO2 PMT for the given patch " + args[1]);
 
         Pmt pmt = new Pmt();
-        String[] commitsInTheGivenPatch = pmt.getThePublicGitCommitId(jsonArray);
+        String[] commitsInTheGivenPatch = null;
+        if (jsonArray != null) {
+            commitsInTheGivenPatch = pmt.getThePublicGitCommitId(jsonArray);
+        }
         logger.info("Commits received from WSO2 PMT are saved in an array successfully");
 
         logger.info("Commits received from WSO2 PMT are saved in an array successfully");
@@ -59,12 +62,17 @@ public class MainClass {
         String gitHubToken = args[2];
 
         BlameCommit blameCommit = new BlameCommit();
-        Set<String> commitHashObtainedForPRReview = blameCommit.obtainingRepoNamesForCommitHashes(gitHubToken, commitsInTheGivenPatch, restApiCaller);
+        Set<String> commitHashObtainedForPRReview = null;
+        if (commitsInTheGivenPatch != null) {
+            commitHashObtainedForPRReview = blameCommit.obtainingRepoNamesForCommitHashes(gitHubToken, commitsInTheGivenPatch, restApiCaller);
+        }
         logger.info("Author commits that introduce bug lines of code to the repository are saved in commitHashObtainedForPRReview SET successfully");
 
         logger.info("Author commits that introduce bug lines of code to the repository are saved in commitHashObtainedForPRReview SET successfully");
 
         Reviewers reviewers = new Reviewers();
-        reviewers.findingReviewers(commitHashObtainedForPRReview, gitHubToken);
+        if (commitHashObtainedForPRReview != null) {
+            reviewers.findingReviewers(commitHashObtainedForPRReview, gitHubToken);
+        }
     }
 }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
@@ -40,7 +40,13 @@ public class MainClass {
         String pmtUrl = "http://umt.private.wso2.com:9765/codequalitymatricesapi/1.0.0//properties?path=/_system/governance/patchs/" + patchId;
 
         RestApiCaller restApiCaller = new RestApiCaller();
-        JSONArray jsonArray = (JSONArray) restApiCaller.callingTheAPI(pmtUrl, pmtToken, false, false);
+        JSONArray jsonArray = null;
+        try {
+            jsonArray = (JSONArray) restApiCaller.callingTheAPI(pmtUrl, pmtToken, false, false);
+        } catch (Exception e) {
+            System.out.println(e.getMessage()+"cause"+e.getCause());
+
+        }
 
         logger.info("JSON response is received successfully from WSO2 PMT for the given patch " + args[1]);
 

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/MainClass.java
@@ -34,34 +34,32 @@ public class MainClass {
     public static void main(String[] args) {
         logger.info(" Main method got executed");
 
-//        String pmtToken = args[0];
-//        String patchId = args[1];
-//
-//        String pmtUrl = "http://umt.private.wso2.com:9765/codequalitymatricesapi/1.0.0//properties?path=/_system/governance/patchs/" + patchId;
-//
-//        RestApiCaller restApiCaller = new RestApiCaller();
-//        JSONArray jsonArray = (JSONArray) restApiCaller.callingTheAPI(pmtUrl, pmtToken, false, false);
+        String pmtToken = args[0];
+        String patchId = args[1];
+
+        String pmtUrl = "http://umt.private.wso2.com:9765/codequalitymatricesapi/1.0.0//properties?path=/_system/governance/patchs/" + patchId;
+
+        RestApiCaller restApiCaller = new RestApiCaller();
+        JSONArray jsonArray = (JSONArray) restApiCaller.callingTheAPI(pmtUrl, pmtToken, false, false);
 
         logger.info("JSON response is received successfully from WSO2 PMT for the given patch " + args[1]);
 
-//        Pmt pmt = new Pmt();
-//        String[] commitsInTheGivenPatch = pmt.getThePublicGitCommitId(jsonArray);
+        Pmt pmt = new Pmt();
+        String[] commitsInTheGivenPatch = pmt.getThePublicGitCommitId(jsonArray);
         logger.info("Commits received from WSO2 PMT are saved in an array successfully");
 
         logger.info("Commits received from WSO2 PMT are saved in an array successfully");
 
-//        String gitHubToken = args[2];
-//
-//        BlameCommit blameCommit = new BlameCommit();
-//        Set<String> commitHashObtainedForPRReview = blameCommit.obtainingRepoNamesForCommitHashes(gitHubToken, commitsInTheGivenPatch, restApiCaller);
+        String gitHubToken = args[2];
+
+        BlameCommit blameCommit = new BlameCommit();
+        Set<String> commitHashObtainedForPRReview = blameCommit.obtainingRepoNamesForCommitHashes(gitHubToken, commitsInTheGivenPatch, restApiCaller);
         logger.info("Author commits that introduce bug lines of code to the repository are saved in commitHashObtainedForPRReview SET successfully");
 
         logger.info("Author commits that introduce bug lines of code to the repository are saved in commitHashObtainedForPRReview SET successfully");
 
-//        Reviewers reviewers = new Reviewers();
-//        reviewers.findingReviewers(commitHashObtainedForPRReview, gitHubToken);
+        Reviewers reviewers = new Reviewers();
+        reviewers.findingReviewers(commitHashObtainedForPRReview, gitHubToken);
 
-        GitHubAuthentication gitHubAuthentication= new GitHubAuthentication();
-        gitHubAuthentication.gettingGithubClient();
     }
 }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Pmt.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Pmt.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.wso2.code.quality.matrices;

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Pmt.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Pmt.java
@@ -22,6 +22,8 @@ import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.stream.IntStream;
+
 /**
  * This class is used for obtaining the commit hashes that belongs to the given patch
  */
@@ -45,17 +47,14 @@ public class Pmt {
                 JSONArray tempCommitsJSONArray = (JSONArray) jsonObject.get("value");
                 //initializing the patchInformation_svnRevisionpublic array
                 patchInformation_svnRevisionpublic = new String[tempCommitsJSONArray.length()];
-                for (int j = 0; j < tempCommitsJSONArray.length(); j++) {
-                    patchInformation_svnRevisionpublic[j] = ((String) tempCommitsJSONArray.get(j)).trim();     // for ommiting the white spaces at the begingin and end of the commits
-                }
+                // for ommiting the white spaces at the begingin and end of the commits
+                IntStream.range(0, tempCommitsJSONArray.length()).forEach(j -> patchInformation_svnRevisionpublic[j] = ((String) tempCommitsJSONArray.get(j)).trim());
 
                 logger.info(" The commits hashes obtained from WSO2 PMT are successfully saved to an array");
 
                 System.out.println("The commit Ids are");
                 //            for printing all the commits ID associated with a patch
-                for (String tmp : patchInformation_svnRevisionpublic) {
-                    System.out.println(tmp);
-                }
+                IntStream.range(0, patchInformation_svnRevisionpublic.length).mapToObj(i1 -> patchInformation_svnRevisionpublic[i1]).forEach(System.out::println);
                 System.out.println();
                 break;
             }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/RestApiCaller.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/RestApiCaller.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.wso2.code.quality.matrices;

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/RestApiCaller.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/RestApiCaller.java
@@ -38,7 +38,7 @@ import java.io.InputStreamReader;
 
 public class RestApiCaller {
 
-    static Logger restApiCallerLogger = Logger.getLogger(RestApiCaller.class);
+    private static Logger logger = Logger.getLogger(RestApiCaller.class);
 
     /**
      * calling the relevant API and saving the output to a file
@@ -94,13 +94,13 @@ public class RestApiCaller {
                 JSONArray jsonArray = (JSONArray) json;
                 returnedObject = jsonArray;
             }
-            restApiCallerLogger.info("JSON response is passed after calling the given REST API");
+            logger.info("JSON response is passed after calling the given REST API");
 
         } catch (ClientProtocolException e) {
-            restApiCallerLogger.error("ClientProtocolException when calling the REST API", e);
+            logger.error("ClientProtocolException when calling the REST API", e);
             throw new CodeQualityMatricesException("ClientProtocolException when calling the REST API", e);
         } catch (IOException e) {
-            restApiCallerLogger.error("IOException occurred when calling the REST API");
+            logger.error("IOException occurred when calling the REST API");
             throw new CodeQualityMatricesException("IOException occurred when calling the REST API", e);
         } finally {
 

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/RestApiCaller.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/RestApiCaller.java
@@ -18,19 +18,19 @@
 
 package com.wso2.code.quality.matrices;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.log4j.Logger;
-import org.json.JSONTokener;
-import org.json.JSONObject;
 import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 
 /**
  * This class is used to call the REST API of both WSO2 PMT and github.com
@@ -38,7 +38,7 @@ import org.json.JSONArray;
 
 public class RestApiCaller {
 
-    static Logger restApiCallerLogger = Logger.getLogger(RestApiCaller.class.getName());
+    static Logger restApiCallerLogger = Logger.getLogger(RestApiCaller.class);
 
     /**
      * calling the relevant API and saving the output to a file

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Reviewers.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Reviewers.java
@@ -79,7 +79,12 @@ public class Reviewers extends BlameCommit {
             String commitHashForFindingReviewers = (String) commitHashObtainedForPRReviewIterator.next();
             setSearchPullReqeustAPI(commitHashForFindingReviewers);
             // calling the github search API
-            JSONObject rootJsonObject = (JSONObject) callingTheAPI(getSearchPullReqeustAPI(), githubToken, false, true);
+            JSONObject rootJsonObject = null;
+            try {
+                rootJsonObject = (JSONObject) callingTheAPI(getSearchPullReqeustAPI(), githubToken, false, true);
+            } catch (Exception e) {
+                System.out.println(e.getMessage() + "cause" + e.getCause());
+            }
             // reading thus saved json file
             savingPrNumberAndRepoName(rootJsonObject);
         }
@@ -130,7 +135,12 @@ public class Reviewers extends BlameCommit {
             while (prNumberIterator.hasNext()) {
                 int prNumber = (int) prNumberIterator.next();
                 setPullRequestReviewAPIUrl(productLocation, prNumber);
-                JSONArray rootJsonArray = (JSONArray) callingTheAPI(getPullRequestReviewAPIUrl(), githubToken, false, true);
+                JSONArray rootJsonArray = null;
+                try {
+                    rootJsonArray = (JSONArray) callingTheAPI(getPullRequestReviewAPIUrl(), githubToken, false, true);
+                } catch (Exception e) {
+                    System.out.println(e.getMessage() + "cause" + e.getCause());
+                }
                 // for reading the output JSON from above and adding the reviewers to the Set
                 readingTheReviewOutJSON(rootJsonArray, productLocation, prNumber);
             }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Reviewers.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Reviewers.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.wso2.code.quality.matrices;

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Reviewers.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Reviewers.java
@@ -40,7 +40,7 @@ public class Reviewers extends BlameCommit {
     Set<String> approvedReviewers = new HashSet<String>();      // to store the reviewed and approved users of the pull requests
     Set<String> commentedReviewers = new HashSet<String>();     // to store the reviewed and commented users of the pull requests
 
-    private static final Logger reviewersLogger = Logger.getLogger(Reviewers.class);
+    private static final Logger logger = Logger.getLogger(Reviewers.class);
 
     public String getSearchPullReqeustAPI() {
         return searchPullReqeustAPIUrl;
@@ -86,14 +86,16 @@ public class Reviewers extends BlameCommit {
                 System.out.println(e.getMessage() + "cause" + e.getCause());
             }
             // reading thus saved json file
-            savingPrNumberAndRepoName(rootJsonObject);
+            if (rootJsonObject != null) {
+                savingPrNumberAndRepoName(rootJsonObject);
+            }
         }
-        reviewersLogger.info("PR numbers which introduce bug lines of code with their relevant repository are saved successfully to mapContainingPRNoAgainstRepoName map");
+        logger.info("PR numbers which introduce bug lines of code with their relevant repository are saved successfully to mapContainingPRNoAgainstRepoName map");
         savingReviewersToList(githubToken);
-        reviewersLogger.info("List of approved reviwers and comment users of the PRs which introduce bug lines to repository are saved in commentedReviewers and approvedReviewers list ");
+        logger.info("List of approved reviwers and comment users of the PRs which introduce bug lines to repository are saved in commentedReviewers and approvedReviewers list ");
         // printing the list of reviewers of pull requests
         printReviewUsers();
-        reviewersLogger.info("Names of approved reviewers and commented reviewers are printed successfully");
+        logger.info("Names of approved reviewers and commented reviewers are printed successfully");
     }
 
     /**
@@ -142,7 +144,9 @@ public class Reviewers extends BlameCommit {
                     System.out.println(e.getMessage() + "cause" + e.getCause());
                 }
                 // for reading the output JSON from above and adding the reviewers to the Set
-                readingTheReviewOutJSON(rootJsonArray, productLocation, prNumber);
+                if (rootJsonArray != null) {
+                    readingTheReviewOutJSON(rootJsonArray, productLocation, prNumber);
+                }
             }
         }
     }

--- a/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Reviewers.java
+++ b/CodeQualityMatricesProject/src/main/java/com/wso2/code/quality/matrices/Reviewers.java
@@ -18,16 +18,16 @@
 
 package com.wso2.code.quality.matrices;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 /**
  * This class is used to find the revierwers of the buggy lines of code
@@ -40,7 +40,7 @@ public class Reviewers extends BlameCommit {
     Set<String> approvedReviewers = new HashSet<String>();      // to store the reviewed and approved users of the pull requests
     Set<String> commentedReviewers = new HashSet<String>();     // to store the reviewed and commented users of the pull requests
 
-    private static final Logger reviewersLogger = Logger.getLogger(Reviewers.class.getName());
+    private static final Logger reviewersLogger = Logger.getLogger(Reviewers.class);
 
     public String getSearchPullReqeustAPI() {
         return searchPullReqeustAPIUrl;


### PR DESCRIPTION
Did the fixes asked in the code review

- Use SDK instead of calling the APIs directly
Since some of the existing REST API being provided by github.com are in preview mode and they can be changed in any time soon, calling an API directly by using the URL is not a good practice. Hence we need to use an SDK to call the API. As the program uses graphql API in Github if there is no SDK available for using GraphQL API, need to write a  generic class for calling API and use it as a SDK      

- Avoiding writing the API response to a file
The current program invokes IO operation to write the response to a file and again invoke IO operation to read the same file which is not required as we can store the response in memory and process it
 
- Use  WSO2 coding conventions in naming the classes and packages
 Needed to avoid use of camel case in naming packages and use names having a proper meaning in naming classes.

- Take all the arguments needed in one line and as main class arguments
Since this is going to be used in PMT to record the relevant reviewers and authors of the buggy lines that are being fixed from a patch and this is not going to be run manually, all the arguments should be passed in single line and as main class arguments

- Avoid throwing exceptions in main method
Since exceptions thrown from the main method are required to be handled by the invoking user, need to avoid throwing exceptions in main method

- Avoid  use of too many levels of if conditions
Since having too many levels of if conditions is not a good practice and may result a harder reading code, need to rethink the logic of evaluating  